### PR TITLE
Update h2config.h

### DIFF
--- a/engine/h2shared/h2config.h
+++ b/engine/h2shared/h2config.h
@@ -116,7 +116,7 @@
    undef to a define :  in that case, player must use the -noportals
    command line argument to disable mission pack support.
    ================================================================== */
-#undef	H2MP
+define H2MP 1
 /* When building HexenWorld or demo-specific, H2MP mustn't be defined */
 #if defined(H2W) || defined(DEMOBUILD)
 #undef	H2MP


### PR DESCRIPTION
This autoloads H2MP to eliminate: "Host_Error: Model *1 not found."